### PR TITLE
Result wrap + Ubuntu 18 compatibility

### DIFF
--- a/CROCd3mWrapper/requirements.txt
+++ b/CROCd3mWrapper/requirements.txt
@@ -7,4 +7,4 @@ scikit-learn==0.19.1
 scipy==1.0.1
 spacy==2.0.11
 tensorflow==1.7.0
-tesserocr==2.2.2
+tesserocr==2.3.1

--- a/CROCd3mWrapper/wrapper.py
+++ b/CROCd3mWrapper/wrapper.py
@@ -157,7 +157,7 @@ class croc(PrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
             imagepath_df = pd.concat(
                 [imagepath_df.reset_index(drop=True), result_df], axis=1)
 
-        return imagepath_df
+        return CallResult(imagepath_df)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Wraps returned Dataframe in CallResult for TA2 use
2. Updates the tesserocr version to latest to address issues with Ubuntu 18 compatibility 