### PR TITLE
Clear tensorflow session info

### DIFF
--- a/CROCd3mWrapper/wrapper.py
+++ b/CROCd3mWrapper/wrapper.py
@@ -4,6 +4,7 @@ import typing
 from json import loads
 import numpy as np
 import pandas as pd
+from keras import backend as K
 
 from nk_croc import *
 
@@ -180,6 +181,9 @@ class croc(PrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
 
             imagepath_df = pd.concat(
                 [imagepath_df.reset_index(drop=True), result_df], axis=1)
+
+        # clear the session to avoid tensorflow state errors when invoking downstream primitives
+        K.clear_session()
 
         return CallResult(imagepath_df)
 


### PR DESCRIPTION
When running croc in combination with unicorn and simon as part of an ingest pipeline, we were observing errors similar to:

`ValueError: Tensor Tensor("Placeholder:0", shape=(1, 1), dtype=int32) is not an element of this graph.`

The errors don't occur when Croc is run in isolation, only when it is combined with other Tensorflow primitives.  Clearing the session after an invocation fixes the issue in our testing.