### PR TITLE
removes trailing slashes that caused path errors

### DIFF
--- a/CROCd3mWrapper/wrapper.py
+++ b/CROCd3mWrapper/wrapper.py
@@ -104,7 +104,7 @@ class croc(PrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
 
     def __init__(self, *, hyperparams: Hyperparams, volumes: typing.Dict[str,str]=None)-> None:
         super().__init__(hyperparams=hyperparams, volumes=volumes)
-        
+
         self.volumes = volumes
 
     def fit(self) -> None:
@@ -153,10 +153,10 @@ class croc(PrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
         output_labels = self.hyperparams['output_labels']
 
         imagepath_df = inputs
-        image_analyzer = Croc(weights_path=self.volumes["croc_weights"]+"/inception_v3_weights_tf_dim_ordering_tf_kernels.h5/",
-                             isa_path=self.volumes["croc_weights"]+"/is_a.py/",
-                             id_mapping_path=self.volumes["croc_weights"]+"/id_mapping.py/",
-                             spacy_path=self.volumes["croc_weights"]+"/en_core_web_md-1.2.1.tar.gz/")
+        image_analyzer = Croc(weights_path=self.volumes["croc_weights"]+"/inception_v3_weights_tf_dim_ordering_tf_kernels.h5",
+                             isa_path=self.volumes["croc_weights"]+"/is_a.py",
+                             id_mapping_path=self.volumes["croc_weights"]+"/id_mapping.py",
+                             spacy_path=self.volumes["croc_weights"]+"/en_core_web_md-1.2.1.tar.gz")
 
         for i, ith_column in enumerate(target_columns):
             # initialize an empty dataframe


### PR DESCRIPTION
After applying the fix from newknowledge/d3m_croc#5 the following error was generated:

```shell
  File "/home/chris/.env/distil-pipeline-runner/src/crocd3mwrapper/CROCd3mWrapper/wrapper.py", line 159, in produce
    spacy_path=self.volumes["croc_weights"]+"/en_core_web_md-1.2.1.tar.gz/")
  File "/home/chris/dev/git_work/d3m_croc/d3m_croc/d3m_croc.py", line 25, in __init__
    self.model = InceptionV3(weights=weights_path)
  File "/home/chris/.env/distil-pipeline-runner/lib/python3.6/site-packages/keras/applications/inception_v3.py", line 144, in InceptionV3
    raise ValueError('The `weights` argument should be either '
ValueError: The `weights` argument should be either `None` (random initialization), `imagenet` (pre-training on ImageNet), or the path to the weights file to be loaded.
```

The trailing slash was responsible for the error.